### PR TITLE
feat: change `FingerprintJsProAgent` constructor interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ import { FingerprintJsProAgent } from '@fingerprintjs/fingerprintjs-pro-react-na
 useEffect(async () => {
   async function getVisitorInfo() {
     try {
-      const FingerprintJSClient = new FingerprintJsProAgent('PUBLIC_API_KEY', 'REGION'); // Region may be 'us', 'eu', or 'ap'
+      const FingerprintJSClient = new FingerprintJsProAgent({ apiKey: 'PUBLIC_API_KEY', region: 'REGION' }); // Region may be 'us', 'eu', or 'ap'
       const visitorId = await FingerprintJSClient.getVisitorId(); // Use this method if you need only visitorId
       const visitorData = await FingerprintJSClient.getVisitorData(); // Use this method if you need additional information about visitor
       // use visitor data in your code
@@ -203,8 +203,8 @@ It can be requested using the `extendedResponseFormat`: true parameter. See more
 #### Providing `extendedResponseFormat` with API Client approach
 
 ```javascript
-const FingerprintJSClient = new FingerprintJsProAgent('PUBLIC_API_KEY', 'REGION', null, true); // Region may be 'us', 'eu', or 'ap'
-// =====================================================================================^^^^^
+const FingerprintJSClient = new FingerprintJsProAgent({ apiKey: 'PUBLIC_API_KEY', region: 'REGION', extendedResponseFormat: true }); // Region may be 'us', 'eu', or 'ap'
+// =================================================================================================^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
 ### `LinkedId` and `tags`

--- a/__tests__/helpers.tsx
+++ b/__tests__/helpers.tsx
@@ -1,12 +1,12 @@
 import React, { PropsWithChildren } from 'react'
 import { FingerprintJsProProvider } from '../src'
-import { FingerprintJsProProviderOptions } from '../src/FingerprintJsProProvider'
+import { FingerprintJsProAgentParams } from '../src/types'
 
-export const getDefaultLoadOptions = (): FingerprintJsProProviderOptions => ({
+export const getDefaultLoadOptions = (): FingerprintJsProAgentParams => ({
   apiKey: 'test_api_key',
 })
 
 export const createWrapper =
-  (loadOptions: FingerprintJsProProviderOptions = getDefaultLoadOptions()) =>
+  (loadOptions: FingerprintJsProAgentParams = getDefaultLoadOptions()) =>
   ({ children }: PropsWithChildren<{}>): JSX.Element =>
     <FingerprintJsProProvider {...loadOptions}>{children}</FingerprintJsProProvider>

--- a/src/FingerprintJsProAgent.ts
+++ b/src/FingerprintJsProAgent.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native'
 import { UnknownError, unwrapError } from './errors'
-import type { Region, Tags, VisitorData } from './types'
+import type { FingerprintJsProAgentParams, Tags, VisitorData } from './types'
 import * as packageInfo from '../package.json'
 
 type VisitorId = string
@@ -13,12 +13,9 @@ export class FingerprintJsProAgent {
   /**
    * Initialises FingerprintJS Pro Agent with certain settings
    *
-   * @param apiKey your public API key that authenticates the agent with the API
-   * @param region which region to use
-   * @param endpointUrl server API URL, should be only used with Subdomain integration
-   * @param extendedResponseFormat set this flag to get response in extended format
+   * @param params
    */
-  constructor(apiKey: string, region?: Region, endpointUrl?: string, extendedResponseFormat = false) {
+  constructor({ apiKey, region, endpointUrl, extendedResponseFormat = false }: FingerprintJsProAgentParams) {
     try {
       NativeModules.RNFingerprintjsPro.init(apiKey, region, endpointUrl, extendedResponseFormat, packageInfo.version)
     } catch (e) {

--- a/src/FingerprintJsProProvider.tsx
+++ b/src/FingerprintJsProProvider.tsx
@@ -1,31 +1,7 @@
 import React, { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FingerprintJsProAgent } from './FingerprintJsProAgent'
 import { FingerprintJsProContext } from './FingerprintJsProContext'
-import { Region, Tags } from './types'
-
-/**
- * Configuration options for the {@link FingerprintJsProProvider}
- *
- * @group Hooks approach
- */
-export interface FingerprintJsProProviderOptions {
-  /**
-   * Your public API key that authenticates the agent with the API
-   */
-  apiKey: string
-  /**
-   * Which region to use
-   */
-  region?: Region
-  /**
-   * Server API URL, should be only used with Subdomain integration
-   */
-  endpointUrl?: string
-  /**
-   * Set this flag to get response in extended format
-   */
-  extendedResponseFormat?: boolean
-}
+import { FingerprintJsProAgentParams, Tags } from './types'
 
 /**
  * Provides the FingerprintJsProContext to its child components.
@@ -42,13 +18,10 @@ export interface FingerprintJsProProviderOptions {
  */
 export function FingerprintJsProProvider({
   children,
-  apiKey,
-  region,
-  endpointUrl,
-  extendedResponseFormat,
-}: PropsWithChildren<FingerprintJsProProviderOptions>) {
+  ...fingerprintJsProAgentParams
+}: PropsWithChildren<FingerprintJsProAgentParams>) {
   const [client, setClient] = useState<FingerprintJsProAgent>(
-    () => new FingerprintJsProAgent(apiKey, region, endpointUrl, extendedResponseFormat)
+    () => new FingerprintJsProAgent(fingerprintJsProAgentParams)
   )
   const [visitorId, updateVisitorId] = useState('')
 
@@ -67,9 +40,9 @@ export function FingerprintJsProProvider({
     if (firstRender) {
       firstRender.current = false
     } else {
-      setClient(new FingerprintJsProAgent(apiKey, region, endpointUrl, extendedResponseFormat))
+      setClient(new FingerprintJsProAgent(fingerprintJsProAgentParams))
     }
-  }, [apiKey, region, endpointUrl, extendedResponseFormat])
+  }, [fingerprintJsProAgentParams])
 
   const contextValue = useMemo(() => {
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ export { FingerprintJsProAgent } from './FingerprintJsProAgent'
 export { FingerprintJsProProvider } from './FingerprintJsProProvider'
 export { useVisitorData } from './useVisitorData'
 
-export type { FingerprintJsProProviderOptions } from './FingerprintJsProProvider'
 export type {
+  FingerprintJsProAgentParams,
   VisitorQueryContext,
   Region,
   Tags,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,27 @@
+/**
+ * Configuration options for the {@link FingerprintJsProProvider} and {@link FingerprintJsProAgent}
+ *
+ * @group Types and interfaces
+ */
+export interface FingerprintJsProAgentParams {
+  /**
+   * your public API key that authenticates the agent with the API
+   */
+  apiKey: string
+  /**
+   * which region to use
+   */
+  region?: Region
+  /**
+   * server API URL, should be only used with Subdomain integration
+   */
+  endpointUrl?: string
+  /**
+   * set this flag to get response in extended format
+   */
+  extendedResponseFormat?: boolean
+}
+
 export interface QueryResult<TData, TError = Error> {
   /**
    * Visitor identification data


### PR DESCRIPTION
BREAKING CHANGE:
In previous version `FingerprintJsProAgent` constructor had several position arguments. In new version it is one `params` argument of type `FingerprintJsProAgentParams`. Type `FingerprintJsProAgentParams` will be used instead of type `FingerprintJsProProviderOptions`.