### PR TITLE
Don't convert boolean fields of `tag` to int for iOS platform

### DIFF
--- a/ios/JSONTypeConvertor.swift
+++ b/ios/JSONTypeConvertor.swift
@@ -20,7 +20,14 @@ class JSONTypeConvertor {
     }
 
     static func convertObjectToJSONTypeConvertible(_ object: Any) -> JSONTypeConvertible? {
-        if let intValue = object as? Int {
+        // React Native Bridge uses NSBoolean instead of Bool which is a subclass of NSNumber
+        if let number = object as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return number.boolValue
+            } else {
+                return number.intValue
+            }
+        } else if let intValue = object as? Int {
             return intValue
         } else if let stringValue = object as? String {
             return stringValue


### PR DESCRIPTION
The old architecture of React Native uses Objective-C types in the bridge between JavaScript and Swift runtime.
As a result, dictionary fields have types like `NSString`, `NSNumber`, `NSBoolean`...
`NSBoolean` is a subtype of `NSNumber`, so old code automatically converted boolean to number.