### PR TITLE
Integrate `semantic-release-native-dependency-plugin`

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -37,6 +37,21 @@
         ]
       }
     ],
-    "@semantic-release/github"
+    "@semantic-release/github",
+    [
+      "@fingerprintjs/semantic-release-native-dependency-plugin",
+      {
+        "iOS": {
+          "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
+          "dependencyName": "FingerprintPro",
+          "displayName": "Fingerprint iOS SDK"
+        },
+        "android": {
+          "path": "android",
+          "gradleTaskName": "printFingerprintNativeSDKVersion",
+          "displayName": "Fingerprint Android SDK"
+        }
+      }
+    ],
   ]
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@commitlint/cli": "^17.1.2",
     "@fingerprintjs/commit-lint-dx-team": "^0.0.2",
     "@fingerprintjs/conventional-changelog-dx-team": "^0.1.0",
+    "@fingerprintjs/semantic-release-native-dependency-plugin": "^1.0.0",
     "@react-native/eslint-config": "0.76.6",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,6 +1351,11 @@
   dependencies:
     conventional-changelog-conventionalcommits "^7.0.2"
 
+"@fingerprintjs/semantic-release-native-dependency-plugin@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/semantic-release-native-dependency-plugin/-/semantic-release-native-dependency-plugin-1.0.0.tgz#3151203b5fe2112ab9be331eeb36a5a9ec689caf"
+  integrity sha512-z45x28+StJXdDjNdXsnJQZNJujmc6WUYaWLe7/NaStQrdvHBoR62C/uP0gk8WIWuSmJZTuyVkN5EzWD9/reOuQ==
+
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"


### PR DESCRIPTION
This pull request introduces/integrates the `@fingerprintjs/semantic-release-native-dependency-plugin` to resolving native dependency versions for iOS and Android SDKs during the release process. I added the plugin configuration to the `.releaserc` file to handle native dependencies.

## How To Test?

1. Clone the repository: `git clone git@github.com:fingerprintjs/fingerprintjs-pro-react-native.git && cd fingerprintjs-pro-react-native`
2. Checkout to this branch: `git checkout docs/semantic-release-native-dependency-plugin-inter-1122`
3. We need to add some semantic release dependencies because they currently only exists in CI environment:
  - Add `@semantic-release/changelog` dependency: `yarn add -D @semantic-release/changelog@^6.0.3`
  - Add `@semantic-release/exec` dependency: `yarn add -D @semantic-release/exec@^7.0.3`
  - Add `@semantic-release/git` dependency: `yarn add -D @semantic-release/git@^10.0.1`
4. Create an example `feat` commit: `git commit --allow-empty -m "feat: an example feature"`
5. Run semantic release in dry-run mode and check release notes:
```
$ GH_TOKEN=$(gh auth token) npx semantic-release@21.1.1 --dry-run --debug --branches "main,docs/semantic-release-native-dependency-plugin-inter-1122"
...
## 3.4.0 (https://github.com/fingerprintjs/fingerprintjs-pro-react-native/compare/v3.3.1...v3.4.0) (2025-04-01)

### Features

    * an example feature (13222b2 (https://github.com/fingerprintjs/fingerprintjs-pro-react-native/commit/13222b2b31f2bf538cc7344ec38e57d6d4589905))

Fingerprint Android SDK Version Range: `>= 2.7.0 and < 3.0.0`

Fingerprint iOS SDK Version Range: >= `2.7.0 and < 3.0.0`
```

This will verify that the release notes include the correct SDK version ranges.

---

Related Task: INTER-1122