### PR TITLE
INTER-1208: Upgrade semantic-release-native-dependency-plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -41,15 +41,18 @@
     [
       "@fingerprintjs/semantic-release-native-dependency-plugin",
       {
-        "iOS": {
-          "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
-          "dependencyName": "FingerprintPro",
-          "displayName": "Fingerprint iOS SDK"
-        },
-        "android": {
-          "path": "android",
-          "gradleTaskName": "printFingerprintNativeSDKVersion",
-          "displayName": "Fingerprint Android SDK"
+        "heading": "Supported Native SDK Version Range",
+        "platforms": {
+          "iOS": {
+            "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
+            "dependencyName": "FingerprintPro",
+            "displayName": "Fingerprint iOS SDK"
+          },
+          "android": {
+            "path": "android",
+            "gradleTaskName": "printFingerprintNativeSDKVersion",
+            "displayName": "Fingerprint Android SDK"
+          }
         }
       }
     ],

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@commitlint/cli": "^17.1.2",
     "@fingerprintjs/commit-lint-dx-team": "^0.0.2",
     "@fingerprintjs/conventional-changelog-dx-team": "^0.1.0",
-    "@fingerprintjs/semantic-release-native-dependency-plugin": "^1.0.0",
+    "@fingerprintjs/semantic-release-native-dependency-plugin": "^1.1.0",
     "@react-native/eslint-config": "0.76.6",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,10 +1351,10 @@
   dependencies:
     conventional-changelog-conventionalcommits "^7.0.2"
 
-"@fingerprintjs/semantic-release-native-dependency-plugin@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/semantic-release-native-dependency-plugin/-/semantic-release-native-dependency-plugin-1.0.0.tgz#3151203b5fe2112ab9be331eeb36a5a9ec689caf"
-  integrity sha512-z45x28+StJXdDjNdXsnJQZNJujmc6WUYaWLe7/NaStQrdvHBoR62C/uP0gk8WIWuSmJZTuyVkN5EzWD9/reOuQ==
+"@fingerprintjs/semantic-release-native-dependency-plugin@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/semantic-release-native-dependency-plugin/-/semantic-release-native-dependency-plugin-1.1.0.tgz#1aaa7aeef678295e673dc5ad79a9efaf309cc778"
+  integrity sha512-u4PIvfqAedoGI3WDf1afGVHWOnoWcrxl8ewbyBuHfgPZI6qMmH3g/Gx/N4za5mn90VDKYsjILxhvHT9kz6l/IA==
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"


### PR DESCRIPTION
This PR upgrades the `@fingerprintjs/semantic-release-native-dependency-plugin` to version `1.1.0` and updates the `.releaserc` configuration.

## ✅ What's Changed?

- Bumped the plugin version from `^1.0.0` to `^1.1.0` in `package.json` and `yarn.lock`.
- Added a new `heading` field in the plugin configuration.
- Refactored the platform configuration to use the new `platforms` key.

## 🤔 Why?

`v1.1` introduces support for customizing the release notes with a heading. Better readability for generated release notes.

## ✏️ How To Test?

1. **Prepare the project:**
```shell
git clone git@github.com:fingerprintjs/fingerprintjs-pro-react-native.git
cd fingerprintjs-pro-react-native
yarn install
```
2. **Test current (main) behavior:**
```shell
GH_TOKEN=$(gh auth token) npx semantic-release@21.1.1 --dry-run --debug
```
You should see release notes like this:
```
## 3.3.2 (https://github.com/fingerprintjs/fingerprintjs-pro-react-native/compare/v3.3.1...v3.3.2) (2025-04-14)

### Bug Fixes

    * don't convert boolean fields of tag to int for iOS platform (82c91a8)

Fingerprint Android SDK Version Range: `>= 2.7.0` and `< 3.0.0`

Fingerprint iOS SDK Version Range: `>= 2.7.0` and `< 3.0.0`
```
3.  **Test upgraded (changed) behavior:**
```
git checkout docs/upgrade-semantic-release-native-dependency-inter-1208
GH_TOKEN=$(gh auth token) npx semantic-release@21.1.1 --dry-run --debug --branches "main,docs/upgrade-semantic-release-native-dependency-inter-1208"
```
You should see release notes like this:
```
## 3.3.2 (https://github.com/fingerprintjs/fingerprintjs-pro-react-native/compare/v3.3.1...v3.3.2) (2025-04-14)

### Bug Fixes

    * don't convert boolean fields of tag to int for iOS platform (82c91a8)

### Supported Native SDK Version Range

    * Fingerprint Android SDK Version Range: `>= 2.7.0` and `< 3.0.0`
    * Fingerprint iOS SDK Version Range: `>= 2.7.0` and `< 3.0.0`
```

