### PR TITLE
[Test Release] Upgrade semantic-release-native-dependency-plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -37,6 +37,21 @@
         ]
       }
     ],
-    "@semantic-release/github"
+    "@semantic-release/github",
+    [
+      "@fingerprintjs/semantic-release-native-dependency-plugin",
+      {
+        "iOS": {
+          "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
+          "dependencyName": "FingerprintPro",
+          "displayName": "Fingerprint iOS SDK"
+        },
+        "android": {
+          "path": "android",
+          "gradleTaskName": "printFingerprintNativeSDKVersion",
+          "displayName": "Fingerprint Android SDK"
+        }
+      }
+    ],
   ]
 }

--- a/.releaserc
+++ b/.releaserc
@@ -41,15 +41,18 @@
     [
       "@fingerprintjs/semantic-release-native-dependency-plugin",
       {
-        "iOS": {
-          "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
-          "dependencyName": "FingerprintPro",
-          "displayName": "Fingerprint iOS SDK"
-        },
-        "android": {
-          "path": "android",
-          "gradleTaskName": "printFingerprintNativeSDKVersion",
-          "displayName": "Fingerprint Android SDK"
+        "heading": "Supported Native SDK Version Range",
+        "platforms": {
+          "iOS": {
+            "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
+            "dependencyName": "FingerprintPro",
+            "displayName": "Fingerprint iOS SDK"
+          },
+          "android": {
+            "path": "android",
+            "gradleTaskName": "printFingerprintNativeSDKVersion",
+            "displayName": "Fingerprint Android SDK"
+          }
         }
       }
     ],

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@commitlint/cli": "^17.1.2",
     "@fingerprintjs/commit-lint-dx-team": "^0.0.2",
     "@fingerprintjs/conventional-changelog-dx-team": "^0.1.0",
+    "@fingerprintjs/semantic-release-native-dependency-plugin": "^1.0.0",
     "@react-native/eslint-config": "0.76.6",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@commitlint/cli": "^17.1.2",
     "@fingerprintjs/commit-lint-dx-team": "^0.0.2",
     "@fingerprintjs/conventional-changelog-dx-team": "^0.1.0",
-    "@fingerprintjs/semantic-release-native-dependency-plugin": "^1.0.0",
+    "@fingerprintjs/semantic-release-native-dependency-plugin": "^1.1.0",
     "@react-native/eslint-config": "0.76.6",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,10 +1351,10 @@
   dependencies:
     conventional-changelog-conventionalcommits "^7.0.2"
 
-"@fingerprintjs/semantic-release-native-dependency-plugin@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/semantic-release-native-dependency-plugin/-/semantic-release-native-dependency-plugin-1.0.0.tgz#3151203b5fe2112ab9be331eeb36a5a9ec689caf"
-  integrity sha512-z45x28+StJXdDjNdXsnJQZNJujmc6WUYaWLe7/NaStQrdvHBoR62C/uP0gk8WIWuSmJZTuyVkN5EzWD9/reOuQ==
+"@fingerprintjs/semantic-release-native-dependency-plugin@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/semantic-release-native-dependency-plugin/-/semantic-release-native-dependency-plugin-1.1.0.tgz#1aaa7aeef678295e673dc5ad79a9efaf309cc778"
+  integrity sha512-u4PIvfqAedoGI3WDf1afGVHWOnoWcrxl8ewbyBuHfgPZI6qMmH3g/Gx/N4za5mn90VDKYsjILxhvHT9kz6l/IA==
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,6 +1351,11 @@
   dependencies:
     conventional-changelog-conventionalcommits "^7.0.2"
 
+"@fingerprintjs/semantic-release-native-dependency-plugin@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/semantic-release-native-dependency-plugin/-/semantic-release-native-dependency-plugin-1.0.0.tgz#3151203b5fe2112ab9be331eeb36a5a9ec689caf"
+  integrity sha512-z45x28+StJXdDjNdXsnJQZNJujmc6WUYaWLe7/NaStQrdvHBoR62C/uP0gk8WIWuSmJZTuyVkN5EzWD9/reOuQ==
+
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"


### PR DESCRIPTION
Upgraded `@fingerprintjs/semantic-release-native-dependency-plugin` from `v1.0.0` to `v1.1.0`. This version also has new `heading` field in the plugin configuration. Updated `.releaserc` to include the `heading` field with "Supported Native SDK Version Range" value. Also migrated platforms configuration to new structure.