### PR TITLE
Use latest semantic-release-native plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -44,7 +44,7 @@
         "heading": "Supported Native SDK Version Range",
         "platforms": {
           "iOS": {
-            "podSpecJsonPath": "RNFingerprintjsPro.podspec.json",
+            "podSpecPath": "RNFingerprintjsPro.podspec",
             "dependencyName": "FingerprintPro",
             "displayName": "Fingerprint iOS SDK"
           },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@commitlint/cli": "^17.1.2",
     "@fingerprintjs/commit-lint-dx-team": "^0.0.2",
     "@fingerprintjs/conventional-changelog-dx-team": "^0.1.0",
-    "@fingerprintjs/semantic-release-native-dependency-plugin": "^1.1.0",
+    "@fingerprintjs/semantic-release-native-dependency-plugin": "^1.2.0",
     "@react-native/eslint-config": "0.76.6",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-typescript": "^11.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,10 +1351,10 @@
   dependencies:
     conventional-changelog-conventionalcommits "^7.0.2"
 
-"@fingerprintjs/semantic-release-native-dependency-plugin@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/semantic-release-native-dependency-plugin/-/semantic-release-native-dependency-plugin-1.1.0.tgz#1aaa7aeef678295e673dc5ad79a9efaf309cc778"
-  integrity sha512-u4PIvfqAedoGI3WDf1afGVHWOnoWcrxl8ewbyBuHfgPZI6qMmH3g/Gx/N4za5mn90VDKYsjILxhvHT9kz6l/IA==
+"@fingerprintjs/semantic-release-native-dependency-plugin@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/semantic-release-native-dependency-plugin/-/semantic-release-native-dependency-plugin-1.2.0.tgz#7076d2dca91192f1eaeec40af287a6755bbcd236"
+  integrity sha512-m8uBQaOAfxwDfj/3LBO3UotTaPHZ/sSPXXeVecxtL7AL48CJ5CelkDf+VMncggKj9eD9w+bfjQuhTRoFH/7YnA==
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"


### PR DESCRIPTION
Updated the project to use the latest `semantic-release-native` plugin for releasing.