### PR TITLE
Add `prepareCommand, `semanticReleasePlugins` inputs

### DIFF
--- a/.github/workflows/analyze-commits.yml
+++ b/.github/workflows/analyze-commits.yml
@@ -9,3 +9,9 @@ jobs:
   analyze-commits:
     name: Generate docs and coverage report
     uses: fingerprintjs/dx-team-toolkit/.github/workflows/analyze-commits.yml@v1
+    with:
+      prepareCommand: |
+        sudo gem install -n /usr/local/bin cocoapods
+        pod --version
+      semanticReleasePlugins: |
+        @fingerprintjs/semantic-release-native-dependency-plugin@^1.2.1


### PR DESCRIPTION
Adds a custom `prepareCommand` to install CocoaPods, also add native dependency plugin to the extra semantic release plugin list for generate preview.

Related-Task: INTER-1238