### PR TITLE
[INTER-2157][INTER-2158] Update mobile agents to v2.16.0

### DIFF
--- a/.changeset/khaki-insects-hang.md
+++ b/.changeset/khaki-insects-hang.md
@@ -1,5 +1,0 @@
----
-'@fingerprintjs/fingerprintjs-pro-react-native': patch
----
-
-Sample changeset to test release pipeline

--- a/.changeset/update-mobile-agents-2-16-0.md
+++ b/.changeset/update-mobile-agents-2-16-0.md
@@ -1,0 +1,8 @@
+---
+'@fingerprintjs/fingerprintjs-pro-react-native': minor
+---
+
+Update mobile agents to v2.16.0
+
+- [iOS Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2160)
+- [Android Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2160)

--- a/TestProject/ios/Podfile.lock
+++ b/TestProject/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
   - FBLazyVector (0.77.1)
-  - FingerprintPro (2.15.0)
+  - FingerprintPro (2.16.0)
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.77.1):
@@ -1522,7 +1522,7 @@ PODS:
     - React-perflogger (= 0.77.1)
     - React-utils (= 0.77.1)
   - RNFingerprintjsPro (1.0.4):
-    - FingerprintPro (~> 2.15.0)
+    - FingerprintPro (~> 2.16.0)
     - React-Core
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
@@ -1748,7 +1748,7 @@ SPEC CHECKSUMS:
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 79c4b7ec726447eec5f8593379466bd9fde1aa14
-  FingerprintPro: 7769a8745e2df805153c4170c9a10d5a0ab194ff
+  FingerprintPro: d23a0640d3b2febf1d4e877cad3793b74e08e18c
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: ccc24d29d650ea725d582a9a53d57cd417fbdb53
@@ -1811,7 +1811,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 41e9fb63606c32cce924653d2d410cb01ec81286
   ReactCodegen: d9a09a7f7eee93f54d0b4135d5ca66b31b0c42a5
   ReactCommon: 08f4808f02ff115884e870e5cfea689703ff759a
-  RNFingerprintjsPro: 1f39fb67c1f7613e04973379e9b41e3ca0baba5a
+  RNFingerprintjsPro: 5f406b499d66f4946ab43e3da7370d1750c1e716
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 1fd059161b449018342943b095a6d4e69bcaa719
 

--- a/sdk/RNFingerprintjsPro.podspec
+++ b/sdk/RNFingerprintjsPro.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   # See: https://guides.cocoapods.org/using/the-podfile.html#specifying-pod-versions
   # ~> 2.8.2 means >= 2.8.2 and < 2.9.0 (pessimistic operator)
-  s.dependency "FingerprintPro", '~> 2.15.0'
+  s.dependency "FingerprintPro", '~> 2.16.0'
 end

--- a/sdk/android/fingerprint.gradle
+++ b/sdk/android/fingerprint.gradle
@@ -1,4 +1,4 @@
-ext.fingerprint_native_sdk_version = "[2.15.0, 2.16.0)"
+ext.fingerprint_native_sdk_version = "[2.16.0, 2.17.0)"
 
 task printFingerprintNativeSDKVersion {
     doLast {


### PR DESCRIPTION
Release notes:

- [iOS Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2160) (INTER-2157)
- [Android Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2160) (INTER-2158)

Smoke-checked locally (pod/registry resolution + gradle version range); E2E left to CI.

> Note: the repo is still in changesets pre-release mode (tag `test`), so this changeset will publish as a `3.15.0-test.x` prerelease until pre-mode is exited separately.