### PR TITLE
[INTER-2271][INTER-2272] Update mobile agents to v2.17.0

### DIFF
--- a/.changeset/update-mobile-agents-2-17-0.md
+++ b/.changeset/update-mobile-agents-2-17-0.md
@@ -1,0 +1,8 @@
+---
+'@fingerprintjs/fingerprintjs-pro-react-native': minor
+---
+
+Update mobile agents to v2.17.0
+
+- [iOS Agent v2.17.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2170)
+- [Android Agent v2.17.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2170)

--- a/.changeset/update-mobile-agents-2-17-0.md
+++ b/.changeset/update-mobile-agents-2-17-0.md
@@ -4,5 +4,5 @@
 
 Update mobile agents to v2.17.0
 
-- [iOS Agent v2.17.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2170)
-- [Android Agent v2.17.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2170)
+- [iOS Agent v2.17.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2-17-0)
+- [Android Agent v2.17.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2-17-0)

--- a/TestProject/ios/Podfile.lock
+++ b/TestProject/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
   - FBLazyVector (0.77.1)
-  - FingerprintPro (2.16.0)
+  - FingerprintPro (2.17.0)
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.77.1):
@@ -1522,7 +1522,7 @@ PODS:
     - React-perflogger (= 0.77.1)
     - React-utils (= 0.77.1)
   - RNFingerprintjsPro (1.0.4):
-    - FingerprintPro (~> 2.16.0)
+    - FingerprintPro (~> 2.17.0)
     - React-Core
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
@@ -1748,7 +1748,7 @@ SPEC CHECKSUMS:
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 79c4b7ec726447eec5f8593379466bd9fde1aa14
-  FingerprintPro: d23a0640d3b2febf1d4e877cad3793b74e08e18c
+  FingerprintPro: 3841bcfa099c1b5fb0c94218942aac0370667207
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: ccc24d29d650ea725d582a9a53d57cd417fbdb53
@@ -1811,7 +1811,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 41e9fb63606c32cce924653d2d410cb01ec81286
   ReactCodegen: d9a09a7f7eee93f54d0b4135d5ca66b31b0c42a5
   ReactCommon: 08f4808f02ff115884e870e5cfea689703ff759a
-  RNFingerprintjsPro: 5f406b499d66f4946ab43e3da7370d1750c1e716
+  RNFingerprintjsPro: 8906c95f7c814f153d25c6b328d0e9058202f867
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 1fd059161b449018342943b095a6d4e69bcaa719
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Update mobile agents to v2.16.0
 
-  - [iOS Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2160)
-  - [Android Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2160) ([aed5000](https://github.com/fingerprintjs/fingerprintjs-pro-react-native/commit/aed50007498ebd184608c18ec68585586aec27a1))
+  - [iOS Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2-16-0)
+  - [Android Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2-16-0) ([aed5000](https://github.com/fingerprintjs/fingerprintjs-pro-react-native/commit/aed50007498ebd184608c18ec68585586aec27a1))
 
 ### Supported Native SDK Version Range
 
@@ -20,8 +20,8 @@
 
 - Update mobile agents to v2.16.0
 
-  - [iOS Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2160)
-  - [Android Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2160) ([aed5000](https://github.com/fingerprintjs/fingerprintjs-pro-react-native/commit/aed50007498ebd184608c18ec68585586aec27a1))
+  - [iOS Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2-16-0)
+  - [Android Agent v2.16.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2-16-0) ([aed5000](https://github.com/fingerprintjs/fingerprintjs-pro-react-native/commit/aed50007498ebd184608c18ec68585586aec27a1))
 
 ## [3.14.0](https://github.com/fingerprintjs/fingerprintjs-pro-react-native/compare/v3.13.0...v3.14.0) (2026-05-05)
 

--- a/sdk/RNFingerprintjsPro.podspec
+++ b/sdk/RNFingerprintjsPro.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   # See: https://guides.cocoapods.org/using/the-podfile.html#specifying-pod-versions
   # ~> 2.8.2 means >= 2.8.2 and < 2.9.0 (pessimistic operator)
-  s.dependency "FingerprintPro", '~> 2.16.0'
+  s.dependency "FingerprintPro", '~> 2.17.0'
 end

--- a/sdk/android/fingerprint.gradle
+++ b/sdk/android/fingerprint.gradle
@@ -1,4 +1,4 @@
-ext.fingerprint_native_sdk_version = "[2.16.0, 2.17.0)"
+ext.fingerprint_native_sdk_version = "[2.17.0, 2.18.0)"
 
 task printFingerprintNativeSDKVersion {
     doLast {

--- a/tools/metro.js
+++ b/tools/metro.js
@@ -1,4 +1,4 @@
-import path from 'path'
+const path = require('path')
 
 const hoistedModules = ['react', 'react-native']
 


### PR DESCRIPTION
Used this PR as reference: https://github.com/fingerprintjs/fingerprintjs-pro-react-native/pull/246

Release notes:

- [iOS Agent v2.17.0](https://docs.fingerprint.com/docs/changelog-ios-sdk#v2170) (INTER-2271)
- [Android Agent v2.17.0](https://docs.fingerprint.com/docs/changelog-android-sdk#v2170) (INTER-2272)

Testing:

- [x] local tests and CI checks pass
- [x] ran full `e2e-app` web suite against the Fingerprint API with real credentials. 6/6 passing: US/EU region identification, invalid API key handling, and Sealed Results decryption
- [x] `Run tests!` and other "load data" checks passed for Web and iOS/Android simulators