### PR TITLE
chore: add retention period for workflow artifacts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           name: android-app-release-${{ matrix.react-native }}
           path: e2e-app/android/app/build
+          retention-days: 3
 
   e2e-tests-android:
     needs:
@@ -194,6 +195,7 @@ jobs:
         with:
           name: android-detox-artifacts-${{matrix.react-native}}
           path: '**/detox-artifacts'
+          retention-days: 3
 
       - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b
         name: Delete build artifact
@@ -273,6 +275,7 @@ jobs:
         with:
           name: ios-app-release-${{ matrix.react-native }}
           path: e2e-app/ios/build/Build
+          retention-days: 3
 
   e2e-tests-ios:
     env:
@@ -352,6 +355,7 @@ jobs:
         with:
           name: ios-detox-artifacts-${{matrix.react-native}}
           path: '**/detox-artifacts'
+          retention-days: 3
 
       - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b
         name: Delete build artifact


### PR DESCRIPTION
This PR solves INTER-1857 and reduces costs for uploaded artifacts by decreasing `retention-days`.

Based on my research, changing the default [compression level](https://github.com/actions/upload-artifact#altering-compressions-level-speed-v-size) won't significantly reduce costs, since compression time will increase overall compute time, and we store artifacts for only 3 days. 