### PR TITLE
chore: sync assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches-ignore:
       - main
-    paths-ignore:
-      - '**.md'
 
 jobs:
   build-and-check:

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -62,7 +62,7 @@ application to call the native Fingerprint Pro libraries (Android and iOS) and i
 
 ## Requirements and limitations
 
-- React Native versions 0.73 through 0.85 are supported
+- React Native versions 0.73 through 0.86 are supported
 - Expo 51.0.0 or higher is supported
 - Android 6.0 (API level 23+) or higher
 - iOS 13+/tvOS 15+, Swift 5.9 or higher (stable releases)


### PR DESCRIPTION
Synced readme from repo root to `sdk` directory. Should address failed release run: https://github.com/fingerprintjs/fingerprintjs-pro-react-native/actions/runs/31372158741/job/93404514367